### PR TITLE
Fix Tools::stripslashes()

### DIFF
--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -334,8 +334,9 @@ class LiteSpeedCacheCore
 
             if ($includeProd) {
                 $tags = $this->getPurgeTagsByProductOrder(
-                        $product['product_id'],
-                        $includeCats);
+                    $product['product_id'],
+                    $includeCats
+                );
                 if (!empty($tags)) {
                     $pubtags = array_merge($pubtags, $tags);
                 }
@@ -344,8 +345,9 @@ class LiteSpeedCacheCore
         if (!empty($pubtags)) {
             if ($hasStockStatusChange) {
                 $pubtags = array_merge(
-                        $pubtags,
-                        $this->config->getDefaultPurgeTagsByProduct());
+                    $pubtags,
+                    $this->config->getDefaultPurgeTagsByProduct()
+                );
             }
             $tags['pub'] = array_unique($pubtags);
         }

--- a/litespeedcache.php
+++ b/litespeedcache.php
@@ -421,7 +421,7 @@ class LiteSpeedCache extends Module
                     $id = $m[2];
                     $lsc = self::myInstance();
                     if (!isset($lsc->esiInjection['marker'][$id])) {
-                        $id = stripslashes($id);
+                        $id = Tools::stripslashes($id);
                     }
                     if (!isset($lsc->esiInjection['marker'][$id])) {
                         // should not happen


### PR DESCRIPTION
The use of function stripslashes() is forbidden; use Tools::stripslashes() instead