### PR TITLE
Fix warning: Unused variables

### DIFF
--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -332,7 +332,6 @@ class LiteSpeedCacheCore
         }
 
         $pubtags = [];
-        $restype = $resources[0];
         $resid = $resources[1];
 
         switch ($resources[0]) {

--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -332,9 +332,10 @@ class LiteSpeedCacheCore
         }
 
         $pubtags = [];
+        $restype = $resources[0];
         $resid = $resources[1];
 
-        switch ($resources[0]) {
+        switch ($restype) {
             case 'categories':
                 $pubtags[] = Conf::TAG_PREFIX_CATEGORY . $resid;
                 break;

--- a/controllers/admin/AdminLiteSpeedCacheCustomizeController.php
+++ b/controllers/admin/AdminLiteSpeedCacheCustomizeController.php
@@ -429,7 +429,7 @@ class AdminLiteSpeedCacheCustomizeController extends ModuleAdminController
     private function getModuleOptions()
     {
         $moduleOptions = array();
-        $is17 = version_compare(_PS_VERSION_, '1.7.0.0', '>=');
+        //$is17 = version_compare(_PS_VERSION_, '1.7.0.0', '>=');
         if ($this->display == 'edit' || $this->display == 'view') {
             $name = $this->current_id;
             $moduleOptions[] = array(

--- a/controllers/admin/AdminLiteSpeedCacheCustomizeController.php
+++ b/controllers/admin/AdminLiteSpeedCacheCustomizeController.php
@@ -429,7 +429,6 @@ class AdminLiteSpeedCacheCustomizeController extends ModuleAdminController
     private function getModuleOptions()
     {
         $moduleOptions = array();
-        //$is17 = version_compare(_PS_VERSION_, '1.7.0.0', '>=');
         if ($this->display == 'edit' || $this->display == 'view') {
             $name = $this->current_id;
             $moduleOptions[] = array(
@@ -444,8 +443,7 @@ class AdminLiteSpeedCacheCustomizeController extends ModuleAdminController
                 if (($module['active'] == 1)
                     && (!in_array($module['name'], $existing))
                     && ($tmp_instance = Module::getInstanceByName($module['name']))
-                    /*&& (!$is17
-                            || ($tmp_instance instanceof PrestaShop\PrestaShop\Core\Module\WidgetInterface))*/) {
+                ) {
                     $list[$module['name']] = $tmp_instance->displayName;
                 }
             }


### PR DESCRIPTION
Another error with undefined variable that I did not fix:

In file /litespeedcache.php:
 * Variable $count is undefined.

Line	| Code
--------| ------------------------------------------------------
508	|                 $count