### PR TITLE
Update VaryCookie.php

### DIFF
--- a/classes/VaryCookie.php
+++ b/classes/VaryCookie.php
@@ -115,7 +115,7 @@ class LiteSpeedCacheVaryCookie extends CookieCore
             }
         }
 
-        if ($debug_info && $this->debug_header) {
+        if ($debug_info) {
             header("X-LSCACHE-Debug-Vary: $debug_info");
         }
 


### PR DESCRIPTION
Removed reference to $this in non object instance. Fixes 500 errors on page loads.