### PR TITLE
fix: use JSON encoding for module params to avoid separator conflicts

### DIFF
--- a/controllers/front/esi.php
+++ b/controllers/front/esi.php
@@ -179,7 +179,7 @@ class LiteSpeedCacheEsiModuleFrontController extends ModuleFrontController
 
         if(($mp=$item->getParam('mp')) && ($tas = $item->getConf()->getTemplateArgs())){
             $tas1 = explode(',', $tas);
-            $mp1 =  explode(',', $mp);
+            $mp1 = json_decode($mp, true);
             $i=0;
             foreach($tas1 as $mv){
                 $mvs = explode('.', trim($mv));

--- a/litespeedcache.php
+++ b/litespeedcache.php
@@ -749,7 +749,7 @@ class LiteSpeedCache extends Module
         $mp = self::getModuleParams($params, $conf->getTemplateArgs());
 
         if(!empty($mp)){
-            $esiParam['mp']= implode(",", $mp);
+            $esiParam['mp'] = json_encode($mp, JSON_UNESCAPED_UNICODE);
         }
 
         return $lsc->registerEsiMarker($esiParam, $conf);
@@ -778,7 +778,7 @@ class LiteSpeedCache extends Module
         $mp = self::getModuleParams($params, $conf->getTemplateArgs());
 
         if(!empty($mp)){
-            $esiParam['mp']= implode(",", $mp);
+            $esiParam['mp'] = json_encode($mp, JSON_UNESCAPED_UNICODE);
         }
 
         return $lsc->registerEsiMarker($esiParam, $conf);


### PR DESCRIPTION
fix issue #77 