### PR TITLE
Added hook 'actionLiteSpeedCacheInitThirdParty'

### DIFF
--- a/controllers/admin/AdminLiteSpeedCacheCustomizeController.php
+++ b/controllers/admin/AdminLiteSpeedCacheCustomizeController.php
@@ -85,6 +85,8 @@ class AdminLiteSpeedCacheCustomizeController extends ModuleAdminController
         }
         include_once _PS_MODULE_DIR_ . 'litespeedcache/thirdparty/lsc_include.php';
 
+        Hook::exec('actionLiteSpeedCacheInitThirdParty');
+
         $this->initDisplayValues();
         $this->labels = [
             'id' => $this->trans('Module'),

--- a/litespeedcache.php
+++ b/litespeedcache.php
@@ -117,6 +117,8 @@ class LiteSpeedCache extends Module
         }
         if (self::isActiveForUser()) {
             require_once _PS_MODULE_DIR_ . 'litespeedcache/thirdparty/lsc_include.php';
+
+            Hook::exec('actionLiteSpeedCacheInitThirdParty');
         }
     }
     


### PR DESCRIPTION
## Description

This PR adds a new hook called **`actionLiteSpeedCacheInitThirdParty`**, which simplifies the management of **ESI blocks for JavaScript variables added via `Media::addJsDef()`**.

The goal is to provide an official and reusable extension point for handling **dynamic JS variables** that must change on every page refresh, avoiding the issue where values get frozen inside the Full Page Cache.

By using this hook, third-party modules can register their own `LscIntegration` logic more easily, without having to rely on ad-hoc or undocumented solutions.

## How to test

To test this PR, you can use the provided test module: [litespeedtestjs.zip](https://github.com/user-attachments/files/24540568/litespeedtestjs.zip)


The module:
- Prints a JavaScript variable on the homepage
- The variable value changes on every page refresh (e.g. using a timestamp or random value)

### Expected result
- **With this PR applied**: the JS variable value changes correctly on every refresh.
- **Without this PR**: the JS variable value remains the same (cached by Full Page Cache).

This demonstrates the issue with `Media::addJsDef()` and how the new hook enables a clean and reliable solution using ESI.

Attached is a screenshot showing how the JavaScript variable is rendered on the homepage.

The value displayed is intended to change on every page refresh:
- **Without this PR**: the value remains the same due to Full Page Cache.
- **With this PR**: the value updates correctly on each refresh, proving that the ESI-based solution works as expected.

<img width="1343" height="643" alt="Screenshot 2026-01-10 at 09-12-35 Codencode" src="https://github.com/user-attachments/assets/0427b0cb-1d13-46eb-8676-64aa86205cc5" />

## Related ISSUE
https://github.com/litespeedtech/lscache_prestashop/issues/86

I remain available for any clarifications or changes.

Thank you!