### PR TITLE
Fix: Error when saving a category in Back Office (Array to string conversion)

### DIFF
--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -519,8 +519,8 @@ class LiteSpeedCacheCore
         if (!$category->is_root_category) {
             $cats = $category->getParentsCategories();
             if (!empty($cats)) {
-                foreach ($cats as $catid) {
-                    $tags['pub'][] = Conf::TAG_PREFIX_CATEGORY . $catid;
+                foreach ($cats as $cat) {
+                    $tags['pub'][] = Conf::TAG_PREFIX_CATEGORY . $cat['id_category'];
                 }
             }
         }


### PR DESCRIPTION
The issue was caused by iterating over the result of `Category::getParentsCategories()` as if it were a list of category IDs, while the method actually returns an **array of associative arrays**.

As a result, an array was implicitly concatenated to a string when building the cache tags, triggering the PHP warning “**Array to string conversion**”.

Relatid Issue: https://github.com/litespeedtech/lscache_prestashop/issues/88


## How to test
1. Go to **Advanced Parameters → Performance**
2. Enable **Debug mode**
3. Open the Back Office
4. Edit any **category**
5. Click **Save**
6. You should no longer see the error: `An unexpected error occurred. [PrestaShop\PrestaShop\Core\Exception\CoreException code 0]: Warning: Array to string conversion`