### PR TITLE
Add ESI dynamic fragments for product actions and notifications

### DIFF
--- a/classes/Config.php
+++ b/classes/Config.php
@@ -694,6 +694,8 @@ class LiteSpeedCacheConfig
             /* add cache tags * */
             'overrideLayoutTemplate',
             'DisplayOverrideTemplate',
+            'displayDynamicFragmentBefore',
+            'displayDynamicFragmentAfter',
             'filterCategoryContent',
             'filterProductContent',
             'filterCmsContent',

--- a/classes/DynamicFragment.php
+++ b/classes/DynamicFragment.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * LiteSpeed Cache for Prestashop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author   LiteSpeed Technologies
+ * @copyright  Copyright (c) 2017-2020 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
+ * @license     https://opensource.org/licenses/GPL-3.0
+ */
+
+class LiteSpeedCacheDynamicFragment
+{
+    const PRODUCT_ADD_TO_CART = 'product_add_to_cart';
+
+    const NOTIFICATIONS = 'notifications';
+
+    public static function isSupported($params)
+    {
+        return !empty($params['name']) && in_array($params['name'], self::getSupportedNames());
+    }
+
+    public static function buildEsiParam($params)
+    {
+        if (!self::isSupported($params)) {
+            return null;
+        }
+
+        $product = isset($params['product']) ? $params['product'] : false;
+        $idProduct = self::getProductId($product);
+        if ($idProduct <= 0) {
+            return null;
+        }
+
+        $esiParam = [
+            'pt' => LiteSpeedCacheEsiItem::ESI_DYNAMIC_FRAGMENT,
+            'm' => LscDynamicFragment::NAME,
+            'f' => $params['name'],
+            'id_product' => $idProduct,
+            'id_product_attribute' => (int) self::getProductValue($product, 'id_product_attribute'),
+            'id_customization' => (int) self::getProductValue($product, 'id_customization'),
+        ];
+
+        if (!empty($params['template'])) {
+            $esiParam['t'] = $params['template'];
+        }
+
+        return $esiParam;
+    }
+
+    private static function getSupportedNames()
+    {
+        return [
+            self::PRODUCT_ADD_TO_CART,
+            self::NOTIFICATIONS,
+        ];
+    }
+
+    private static function getProductId($product)
+    {
+        $idProduct = self::getProductValue($product, 'id_product');
+
+        return $idProduct ? (int) $idProduct : (int) self::getProductValue($product, 'id');
+    }
+
+    private static function getProductValue($product, $field)
+    {
+        if (empty($product)) {
+            return null;
+        }
+
+        if (is_array($product) || $product instanceof ArrayAccess) {
+            return isset($product[$field]) ? $product[$field] : null;
+        }
+
+        if (is_object($product) && isset($product->$field)) {
+            return $product->$field;
+        }
+
+        return null;
+    }
+}

--- a/classes/EsiItem.php
+++ b/classes/EsiItem.php
@@ -34,6 +34,8 @@ class LiteSpeedCacheEsiItem
 
     const ESI_SMARTYFIELD = 'mf';
 
+    const ESI_DYNAMIC_FRAGMENT = 'df';
+
     const ESI_TOKEN = 'tk';
 
     const ESI_ENV = 'env';
@@ -273,6 +275,11 @@ class LiteSpeedCacheEsiItem
                         $err = 'missing f';
                     } elseif ($param['f'] == 'widget_block' && !isset($param['t'])) {
                         $err = 'missing t';
+                    }
+                    break;
+                case self::ESI_DYNAMIC_FRAGMENT:
+                    if (!isset($param['f']) || $param['f'] == '') {
+                        $err = 'missing f';
                     }
                     break;
                 default:

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>litespeedcache</name>
     <displayName><![CDATA[LiteSpeed Cache Plugin]]></displayName>
-    <version><![CDATA[1.5.2]]></version>
+    <version><![CDATA[1.6.1]]></version>
     <description><![CDATA[Integrates with LiteSpeed Full Page Cache on LiteSpeed Server.]]></description>
     <author><![CDATA[LiteSpeedTech]]></author>
     <tab><![CDATA[administration]]></tab>

--- a/controllers/front/esi.php
+++ b/controllers/front/esi.php
@@ -27,6 +27,7 @@ use LiteSpeedCacheHelper as LSHelper;
 use LiteSpeedCacheLog as LSLog;
 
 require_once _PS_MODULE_DIR_ . 'litespeedcache/classes/HookParamsResolver.php';
+require_once _PS_MODULE_DIR_ . 'litespeedcache/classes/DynamicFragment.php';
 
 class LiteSpeedCacheEsiModuleFrontController extends ModuleFrontController
 {
@@ -104,6 +105,9 @@ class LiteSpeedCacheEsiModuleFrontController extends ModuleFrontController
                 break;
             case EsiItem::ESI_SMARTYFIELD:
                 $this->processSmartyField($item);
+                break;
+            case EsiItem::ESI_DYNAMIC_FRAGMENT:
+                $this->processDynamicFragment($item);
                 break;
             case EsiItem::ESI_JSDEF:
                 LscIntegration::processJsDef($item);
@@ -255,5 +259,153 @@ class LiteSpeedCacheEsiModuleFrontController extends ModuleFrontController
         } else {
             LscIntegration::processModField($item);
         }
+    }
+
+    private function processDynamicFragment($item)
+    {
+        switch ($item->getParam('f')) {
+            case LiteSpeedCacheDynamicFragment::PRODUCT_ADD_TO_CART:
+                $this->processProductAddToCartFragment($item);
+                break;
+            case LiteSpeedCacheDynamicFragment::NOTIFICATIONS:
+                $this->processNotificationsFragment($item);
+                break;
+            default:
+                $item->setFailed('Unknown dynamic fragment ' . $item->getParam('f'));
+        }
+    }
+
+    private function processProductAddToCartFragment($item)
+    {
+        $product = $this->getPresentedProductFromItem($item);
+        if ($product == null) {
+            $item->setFailed('Missing product for add to cart fragment');
+
+            return;
+        }
+
+        $this->assignBaseTemplateVariables();
+        $this->context->smarty->assign('product', $product);
+
+        $template = $item->getParam('t') ?: 'catalog/_partials/product-add-to-cart.tpl';
+        $item->setContent($this->fetchThemeTemplate($template));
+    }
+
+    private function processNotificationsFragment($item)
+    {
+        $notifications = [
+            'error' => [],
+            'warning' => [],
+            'success' => [],
+            'info' => [],
+        ];
+
+        $idProduct = (int) $item->getParam('id_product');
+        if ($idProduct > 0 && (bool) Configuration::get('PS_DISPLAY_AMOUNT_IN_CART')) {
+            $quantities = $this->context->cart->getProductQuantityInAllVariants($idProduct);
+
+            if ($quantities['standalone_quantity'] > 0 && $quantities['pack_quantity'] > 0) {
+                $notifications['info'][] = $this->trans(
+                    'Your cart contains %1s of these products and another %2s of these are included in packs in your cart.',
+                    [$quantities['standalone_quantity'], $quantities['pack_quantity']],
+                    'Shop.Theme.Catalog'
+                );
+            } elseif ($quantities['standalone_quantity'] > 0) {
+                $notifications['info'][] = $this->trans(
+                    'Your cart contains %1s of these products.',
+                    [$quantities['standalone_quantity']],
+                    'Shop.Theme.Catalog'
+                );
+            } elseif ($quantities['pack_quantity'] > 0) {
+                $notifications['info'][] = $this->trans(
+                    '%1s of these products are included in packs in your cart.',
+                    [$quantities['pack_quantity']],
+                    'Shop.Theme.Catalog'
+                );
+            }
+        }
+
+        $this->assignBaseTemplateVariables();
+        $product = $this->getPresentedProductFromItem($item);
+        if ($product != null) {
+            $this->context->smarty->assign('product', $product);
+        }
+        $this->context->smarty->assign('notifications', $notifications);
+
+        $template = $item->getParam('t') ?: '_partials/notifications.tpl';
+        $item->setContent($this->fetchThemeTemplate($template));
+    }
+
+    private function assignBaseTemplateVariables()
+    {
+        $this->assignGeneralPurposeVariables();
+    }
+
+    private function getPresentedProductFromItem($item)
+    {
+        $idProduct = (int) $item->getParam('id_product');
+        if ($idProduct <= 0) {
+            return null;
+        }
+
+        $idProductAttribute = (int) $item->getParam('id_product_attribute');
+        $idCustomization = (int) $item->getParam('id_customization');
+
+        $productObj = new Product($idProduct, true, $this->context->language->id, $this->context->shop->id);
+        if (!Validate::isLoadedObject($productObj)) {
+            return null;
+        }
+
+        $product = (new PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter())->present($productObj);
+        $product['id_product'] = $idProduct;
+        $product['id_product_attribute'] = $idProductAttribute;
+        $product['id_customization'] = $idCustomization;
+        $product['out_of_stock'] = (int) $productObj->out_of_stock;
+        $product['minimal_quantity'] = $this->getProductMinimalQuantity($idProduct, $idProductAttribute, $product);
+        $product['cart_quantity'] = $this->context->cart->getProductQuantity($idProduct, $idProductAttribute)['quantity'];
+        $product['quantity_wanted'] = (int) Tools::getValue('quantity_wanted', max(1, (int) $product['minimal_quantity']));
+        $product['quantity_required'] = max(1, (int) $product['minimal_quantity'] - (int) $product['cart_quantity']);
+        $product = Product::getProductProperties($this->context->language->id, $product, $this->context);
+        if (!is_array($product)) {
+            return null;
+        }
+
+        $factory = new ProductPresenterFactory($this->context, new TaxConfiguration());
+
+        return $factory->getPresenter()->present(
+            $factory->getPresentationSettings(),
+            $product,
+            $this->context->language
+        );
+    }
+
+    private function getProductMinimalQuantity($idProduct, $idProductAttribute, $product)
+    {
+        if ($idProductAttribute > 0) {
+            $combination = new Combination($idProductAttribute);
+            if (Validate::isLoadedObject($combination)) {
+                return (int) $combination->minimal_quantity;
+            }
+        }
+
+        if (isset($product['minimal_quantity'])) {
+            return (int) $product['minimal_quantity'];
+        }
+
+        $productObj = new Product($idProduct, false, $this->context->language->id, $this->context->shop->id);
+        if (Validate::isLoadedObject($productObj)) {
+            return (int) $productObj->minimal_quantity;
+        }
+
+        return 1;
+    }
+
+    private function fetchThemeTemplate($template)
+    {
+        if (substr($template, -4) == '.tpl') {
+            $template = substr($template, 0, -4);
+        }
+
+        return $this->context->smarty->fetch($this->getTemplateFile($template));
     }
 }

--- a/litespeedcache.php
+++ b/litespeedcache.php
@@ -32,6 +32,7 @@ require_once _PS_MODULE_DIR_ . 'litespeedcache/classes/DebugLog.php';
 require_once _PS_MODULE_DIR_ . 'litespeedcache/classes/Config.php';
 require_once _PS_MODULE_DIR_ . 'litespeedcache/classes/Cache.php';
 require_once _PS_MODULE_DIR_ . 'litespeedcache/classes/VaryCookie.php';
+require_once _PS_MODULE_DIR_ . 'litespeedcache/classes/DynamicFragment.php';
 
 class LiteSpeedCache extends Module
 {
@@ -74,6 +75,8 @@ class LiteSpeedCache extends Module
 
     private $esiInjection;
 
+    private $dynamicFragmentLevel;
+
     private static $ccflag = 0; // cache control flag
 
     private static $no_cache_reason = '';
@@ -107,6 +110,7 @@ class LiteSpeedCache extends Module
         $this->esiInjection = ['tracker' => [],
             'marker' => [],
         ];
+        $this->dynamicFragmentLevel = 0;
 
         self::$ccflag |= $this->config->moduleEnabled();
         if (!defined('_LITESPEED_CACHE_')) {
@@ -124,7 +128,7 @@ class LiteSpeedCache extends Module
     
     public static function getVersion()
     {
-        return '1.6.0';
+        return '1.6.1';
     }
 
     public static function isActive()
@@ -386,6 +390,37 @@ class LiteSpeedCache extends Module
 
             return $comment;
         }
+    }
+
+    public function hookDisplayDynamicFragmentBefore($params)
+    {
+        $esiParam = LiteSpeedCacheDynamicFragment::buildEsiParam($params);
+        if ($esiParam == null) {
+            return '';
+        }
+
+        $conf = $this->config->canInjectEsi(LscDynamicFragment::NAME, $esiParam);
+        if ($conf == false) {
+            return '';
+        }
+
+        ++$this->dynamicFragmentLevel;
+
+        return $this->registerEsiMarker($esiParam, $conf);
+    }
+
+    public function hookDisplayDynamicFragmentAfter($params)
+    {
+        if ((self::$ccflag & self::CCBM_CAN_INJECT_ESI) == 0
+                || LiteSpeedCacheDynamicFragment::buildEsiParam($params) == null) {
+            return '';
+        }
+
+        if ($this->dynamicFragmentLevel > 0) {
+            --$this->dynamicFragmentLevel;
+        }
+
+        return self::ESI_MARKER_END;
     }
 
     // called by Media override addJsDef
@@ -732,6 +767,9 @@ class LiteSpeedCache extends Module
         }
 
         $lsc = self::myInstance();
+        if ($lsc->dynamicFragmentLevel > 0) {
+            return false;
+        }
         $m = $module->name;
         $pt = LiteSpeedCacheEsiItem::ESI_RENDERWIDGET;
 
@@ -761,6 +799,9 @@ class LiteSpeedCache extends Module
         }
 
         $lsc = self::myInstance();
+        if ($lsc->dynamicFragmentLevel > 0) {
+            return false;
+        }
         $m = $module->name;
         $pt = LiteSpeedCacheEsiItem::ESI_CALLHOOK;
 

--- a/thirdparty/lsc_include.php
+++ b/thirdparty/lsc_include.php
@@ -28,6 +28,7 @@ include __DIR__ . '/LscIntegration.php';
 // share for all PS versions
 include __DIR__ . '/shared/LscToken.php';
 include __DIR__ . '/shared/LscEnv.php';
+include __DIR__ . '/shared/LscDynamicFragment.php';
 
 // third-party theme integration
 if (version_compare(_PS_VERSION_, '1.7.0.0', '>=')) { // for PS 1.7 only

--- a/thirdparty/shared/LscDynamicFragment.php
+++ b/thirdparty/shared/LscDynamicFragment.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * LiteSpeed Cache for Prestashop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author   LiteSpeed Technologies
+ * @copyright  Copyright (c) 2017-2020 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
+ * @license     https://opensource.org/licenses/GPL-3.0
+ */
+
+use LiteSpeedCacheEsiModConf as EsiConf;
+
+class LscDynamicFragment extends LscIntegration
+{
+    const NAME = 'litespeedcache_dynamic_fragment';
+
+    protected function init()
+    {
+        $confData = [
+            EsiConf::FLD_PRIV => 1,
+            EsiConf::FLD_TAG => LiteSpeedCacheConfig::TAG_CART,
+            EsiConf::FLD_TTL => 0,
+        ];
+        $this->esiConf = new EsiConf(self::NAME, EsiConf::TYPE_BUILTIN, $confData);
+
+        return $this->registerEsiModule();
+    }
+
+    public static function isUsed($name)
+    {
+        return $name == self::NAME;
+    }
+}
+
+LscDynamicFragment::register();

--- a/upgrade/upgrade-1.6.1.php
+++ b/upgrade/upgrade-1.6.1.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * LiteSpeed Cache for Prestashop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author   LiteSpeed Technologies
+ * @copyright  Copyright (c) 2020 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
+ * @license     https://opensource.org/licenses/GPL-3.0
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_1_6_1(LiteSpeedCache $module)
+{
+    return $module->registerHook([
+        'displayDynamicFragmentBefore',
+        'displayDynamicFragmentAfter',
+    ]);
+}


### PR DESCRIPTION
This PR adds support for dynamic ESI fragments on the product page, specifically for:
- the add-to-cart block;
- product notifications.

The goal is to keep context-dependent product page sections dynamic even when the product page is served from full-page cache.

This should address the remaining issues reported in: https://github.com/litespeedtech/lscache_prestashop/issues/94

In particular, the problems that were not covered by the already merged PR: https://github.com/litespeedtech/lscache_prestashop/pull/96

Please note that this solution requires two generic theme hooks:

- `displayDynamicFragmentBefore`
- `displayDynamicFragmentAfter`

These hooks are being proposed for the Hummingbird theme here: https://github.com/PrestaShop/hummingbird/pull/988, if accepted, I will propose the same hooks for the classic theme as well.

Without those hooks in the theme templates, the module cannot wrap the relevant product page fragments before the page output is cached.

@WuhuaChen, what do you think about this approach?
