### PR TITLE
Add purge support for PrestaBlog pages (all pages / by article / by category)

### DIFF
--- a/classes/Config.php
+++ b/classes/Config.php
@@ -45,6 +45,10 @@ class LiteSpeedCacheConfig
 
     const TAG_PREFIX_PCOMMENTS = 'N';
 
+    const TAG_PREFIX_BLOG = 'B'; // prestablog article, bare tag is on every blog page
+
+    const TAG_PREFIX_BLOG_CATEGORY = 'BC'; // prestablog category listing
+
     const TAG_PREFIX_PRIVATE = 'PRIV';
 
     // public tags
@@ -414,7 +418,6 @@ class LiteSpeedCacheConfig
             'IndexController' => self::TAG_HOME, // controller name - tag linked to it
             'ProductController' => '',
             'CategoryController' => '',
-            'prestablogblogModuleFrontController' => '',// permit to cache prestablog module page                          
             'CmsController' => '',
             'ManufacturerController' => '',
             'SupplierController' => '',

--- a/controllers/admin/AdminLiteSpeedCacheManageController.php
+++ b/controllers/admin/AdminLiteSpeedCacheManageController.php
@@ -36,6 +36,8 @@ class AdminLiteSpeedCacheManageController extends ModuleAdminController
 
     private $license_disabled;
 
+    private $has_prestablog;
+
     public function __construct()
     {
         $this->bootstrap = true;
@@ -67,6 +69,8 @@ class AdminLiteSpeedCacheManageController extends ModuleAdminController
                     . $this->trans('Please contact your sysadmin or your host to get a valid LiteSpeed license.');
         }
 
+        $this->has_prestablog = Module::isEnabled('prestablog');
+
         $this->labels = [
             'home' => $this->trans('Home Page'),
             '404' => $this->trans('All 404 Pages'),
@@ -75,6 +79,7 @@ class AdminLiteSpeedCacheManageController extends ModuleAdminController
             'supplier' => $this->trans('All Suppliers Pages'),
             'sitemap' => $this->trans('Site Map'),
             'cms' => $this->trans('All CMS Pages'),
+            'blog' => $this->trans('All Prestablog Pages'),
             'pc' => $this->trans('All Product Comments'),
             'priv' => $this->trans('All Private ESI Blocks'),
             'prod0' => $this->trans('Product'),
@@ -83,6 +88,8 @@ class AdminLiteSpeedCacheManageController extends ModuleAdminController
             'supplier0' => $this->trans('Supplier'),
             'cms0' => $this->trans('CMS'),
             'pc0' => $this->trans('Comments for Product ID'),
+            'blogart0' => $this->trans('Prestablog Article'),
+            'blogcat0' => $this->trans('Prestablog Category'),
             'shop0' => $this->trans('Shop'),
             'affectall' => $this->trans('This will affect all shops'),
         ];
@@ -171,6 +178,10 @@ class AdminLiteSpeedCacheManageController extends ModuleAdminController
             $tags[] = Conf::TAG_PREFIX_CMS;
             $info[] = $this->labels['cms'];
         }
+        if (Tools::getValue('cbPurge_blog')) {
+            $tags[] = Conf::TAG_PREFIX_BLOG;
+            $info[] = $this->labels['blog'];
+        }
         if (Tools::getValue('cbPurge_pc')) {
             $tags[] = Conf::TAG_PREFIX_PCOMMENTS;
             $info[] = $this->labels['pc'];
@@ -221,6 +232,14 @@ class AdminLiteSpeedCacheManageController extends ModuleAdminController
             case 'pc':
                 $pre = Conf::TAG_PREFIX_PCOMMENTS;
                 $desc = $this->labels['pc0'];
+                break;
+            case 'blogart':
+                $pre = Conf::TAG_PREFIX_BLOG;
+                $desc = $this->labels['blogart0'];
+                break;
+            case 'blogcat':
+                $pre = Conf::TAG_PREFIX_BLOG_CATEGORY;
+                $desc = $this->labels['blogcat0'];
                 break;
             case 'shop':
                 $pre = Conf::TAG_PREFIX_SHOP;
@@ -295,22 +314,26 @@ class AdminLiteSpeedCacheManageController extends ModuleAdminController
     {
         $title = $this->trans('Purge by Selection');
         $form = $this->newFieldForm($title, 'list-ul', $title);
+        $cbQuery = [
+            ['id' => 'home', 'name' => $this->labels['home']],
+            ['id' => '404', 'name' => $this->labels['404']],
+            ['id' => 'search', 'name' => $this->labels['search']],
+            ['id' => 'brand', 'name' => $this->labels['brand']],
+            ['id' => 'supplier', 'name' => $this->labels['supplier']],
+            ['id' => 'sitemap', 'name' => $this->labels['sitemap']],
+            ['id' => 'cms', 'name' => $this->labels['cms']],
+        ];
+        if ($this->has_prestablog) {
+            $cbQuery[] = ['id' => 'blog', 'name' => $this->labels['blog']];
+        }
+        $cbQuery[] = ['id' => 'pc', 'name' => $this->labels['pc']];
+        $cbQuery[] = ['id' => 'priv', 'name' => $this->labels['priv']];
         $cbPurge = [
             'type' => 'checkbox',
             'label' => $this->trans('Select All Pages You Want to Purge'),
             'name' => 'cbPurge',
             'values' => [
-                'query' => [
-                    ['id' => 'home', 'name' => $this->labels['home']],
-                    ['id' => '404', 'name' => $this->labels['404']],
-                    ['id' => 'search', 'name' => $this->labels['search']],
-                    ['id' => 'brand', 'name' => $this->labels['brand']],
-                    ['id' => 'supplier', 'name' => $this->labels['supplier']],
-                    ['id' => 'sitemap', 'name' => $this->labels['sitemap']],
-                    ['id' => 'cms', 'name' => $this->labels['cms']],
-                    ['id' => 'pc', 'name' => $this->labels['pc']],
-                    ['id' => 'priv', 'name' => $this->labels['priv']],
-                ],
+                'query' => $cbQuery,
                 'id' => 'id', 'name' => 'name', ],
         ];
         $selCat = [
@@ -361,6 +384,10 @@ class AdminLiteSpeedCacheManageController extends ModuleAdminController
             ['purgeby' => 'pc', 'name' => $this->labels['pc0']],
             ['purgeby' => 'shop', 'name' => $this->labels['shop0']],
         ];
+        if ($this->has_prestablog) {
+            $query[] = ['purgeby' => 'blogart', 'name' => $this->labels['blogart0']];
+            $query[] = ['purgeby' => 'blogcat', 'name' => $this->labels['blogcat0']];
+        }
         $textareaIds = [
             'type' => 'textarea',
             'class' => 'input',

--- a/thirdparty/1.7/LscPrestablog.php
+++ b/thirdparty/1.7/LscPrestablog.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * LiteSpeed Cache for Prestashop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see https://opensource.org/licenses/GPL-3.0 .
+ *
+ * @author   LiteSpeed Technologies
+ * @copyright  Copyright (c) 2017-2025 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
+ * @license     https://opensource.org/licenses/GPL-3.0
+ */
+
+// for integration with PrestaBlog module (https://www.prestablog.fr)
+
+use LiteSpeedCacheConfig as Conf;
+
+class LscPrestablog extends LscIntegration
+{
+    const NAME = 'prestablog';
+
+    const BLOG_CONTROLLER = 'PrestaBlogBlogModuleFrontController';
+
+    protected function init()
+    {
+        // blog pages are public cacheable, tags added in initCacheTagsByController
+        $this->addCacheableControllers([self::BLOG_CONTROLLER => '']);
+        $this->addInitCacheTagAction($this);
+
+        return true;
+    }
+
+    protected function initCacheTagsByController($params)
+    {
+        if (!isset($params['controller'])
+            || strcasecmp(get_class($params['controller']), self::BLOG_CONTROLLER) != 0) {
+            return null;
+        }
+
+        // bare blog tag is on every blog page, allows purge of all blog pages at once
+        $tags = [Conf::TAG_PREFIX_BLOG];
+
+        if (($id = (int) Tools::getValue('id')) > 0) { // single article
+            $tags[] = Conf::TAG_PREFIX_BLOG . $id;
+        } elseif (($catid = (int) Tools::getValue('c')) > 0) { // category listing
+            $tags[] = Conf::TAG_PREFIX_BLOG_CATEGORY . $catid;
+        }
+
+        return $tags;
+    }
+}
+
+LscPrestablog::register();

--- a/thirdparty/lsc_include.php
+++ b/thirdparty/lsc_include.php
@@ -39,6 +39,7 @@ if (version_compare(_PS_VERSION_, '1.7.0.0', '>=')) { // for PS 1.7 only
     // integrated modules, feel free to comment out the modules you don't use
     include __DIR__ . '/1.7/LscGdprPro.php';
     include __DIR__ . '/1.7/LscPscartdropdown.php';
+    include __DIR__ . '/1.7/LscPrestablog.php';
 
     // integrated theme modules, feel free to comment out the themes you don't use
     include __DIR__ . '/1.7/iqit/loader.php';  // warehouse theme


### PR DESCRIPTION
Follow-up to #55, which made prestablog blog pages cacheable but left them without any specific cache tag, so they could only be flushed by purging all shop pages.

## What this adds

**Cache tags on blog pages** via a new third-party integration (`thirdparty/1.7/LscPrestablog.php`), following the existing LscIntegration pattern:
- `B` on every blog page (index, articles, category listings, author pages, archives) — allows purging all blog pages at once
- `B<id>` on a single article page
- `BC<id>` on a category listing (pagination included)

The integration also takes over registering the blog front controller as cacheable (previously hardcoded in Config.php by #55), so it is now only registered when the prestablog module is actually installed and enabled.

**Manual purge controls** in the Cache Management page, consistent with the native entities:
- "All Prestablog Pages" checkbox in *Purge by Selection*
- "Prestablog Article" and "Prestablog Category" ID types in *Purge by ID*

These controls only show up when prestablog is installed and enabled (`Module::isEnabled('prestablog')`); shops without prestablog see no change.

## Notes

- Purging a blog category flushes its listing pages only, mirroring the native behavior for shop categories.
- Automatic purge on article save is intentionally left out to keep this PR small; it could be a follow-up using the `actionObjectNewsClass*After` hooks (prestablog's NewsClass is an ObjectModel).
- No behavior change for PS 1.6 (integration is loaded in the 1.7+ branch of lsc_include.php, matching prestablog's current PS 1.7+ requirement).

Tested on PrestaShop 8.2 with prestablog installed (tags verified on front pages, purges verified from the Cache Management page) and on a shop without prestablog (no UI change, no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)